### PR TITLE
Integrate services into parallax and refine painpoint layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,10 +135,8 @@
                         Schwierige Kommunikation mit Ihrem Dienstleister?
                     </h2>
                 </div>
-            </div>
-            <div class="painpoint-scroll-spacer"></div>
-        </section>
-        <section id="services" class="py-20 px-4 bg-gray-100">
+
+                <section id="services" class="py-20 px-4 bg-gray-100">
             <div class="container mx-auto max-w-4xl">
                 <div class="flex flex-col md:flex-row justify-between items-center mb-12">
                     <div>
@@ -228,6 +226,8 @@
                     </a>
                 </div>
 
+            </div>
+        </section>
             </div>
         </section>
 

--- a/script.js
+++ b/script.js
@@ -74,37 +74,38 @@ document.addEventListener('DOMContentLoaded', function() {
     const stickyContainer = document.querySelector('.painpoint-sticky-container');
     const painpointTexts = document.querySelectorAll('.painpoint-text');
     const numPainpoints = painpointTexts.length;
+    const totalStates = numPainpoints + 1;
 
     if (painpointSection && stickyContainer && painpointTexts.length > 0) {
         
-        painpointTexts[0].classList.add('active');
-        stickyContainer.classList.add('state-1');
+          painpointTexts[0].classList.add('active');
+          stickyContainer.classList.add('state-1');
 
         window.addEventListener('scroll', () => {
             const rect = painpointSection.getBoundingClientRect();
             
             if (rect.top <= 0 && rect.bottom >= window.innerHeight) {
                 const scrollProgress = -rect.top / (painpointSection.scrollHeight - window.innerHeight);
-                let currentIndex = Math.floor(scrollProgress * numPainpoints);
-                currentIndex = Math.min(numPainpoints - 1, currentIndex);
+                  let currentIndex = Math.floor(scrollProgress * totalStates);
+                  currentIndex = Math.min(totalStates - 1, currentIndex);
 
-                painpointTexts.forEach((text, index) => {
-                    if (index === currentIndex) {
-                        text.classList.add('active');
-                    } else {
-                        text.classList.remove('active');
-                    }
-                });
+                  painpointTexts.forEach((text, index) => {
+                      if (index === currentIndex && currentIndex < numPainpoints) {
+                          text.classList.add('active');
+                      } else {
+                          text.classList.remove('active');
+                      }
+                  });
 
-                const currentStateClass = 'state-' + (currentIndex + 1);
-                for (let i = 1; i <= numPainpoints; i++) {
-                    stickyContainer.classList.remove('state-' + i);
-                }
-                stickyContainer.classList.add(currentStateClass);
+                  const currentStateClass = 'state-' + (currentIndex + 1);
+                  for (let i = 1; i <= totalStates; i++) {
+                      stickyContainer.classList.remove('state-' + i);
+                  }
+                  stickyContainer.classList.add(currentStateClass);
             }
         });
     }
-    // --- ENDE: Painpoint Parallax Scroll-Logik ---
+      // --- ENDE: Painpoint Parallax Scroll-Logik ---
 
     const burgerButton = document.getElementById('burger-menu-button');
     const closeButton = document.getElementById('close-menu-button');

--- a/style.css
+++ b/style.css
@@ -253,9 +253,10 @@ body {
 }
 
 /* --- START: Painpoint Parallax Bereich --- */
+/* --- START: Painpoint Parallax Bereich --- */
 #painpoint-parallax {
     position: relative;
-    height: 400vh;
+    min-height: 500vh;
 }
 .painpoint-sticky-container {
     position: sticky;
@@ -263,17 +264,14 @@ body {
     height: 100vh;
     width: 100%;
     overflow: hidden;
-    background-color: #FF5722;
+    background-color: #1a1a1a;
     transition: background-color 0.6s cubic-bezier(0.23, 1, 0.32, 1);
 }
-.painpoint-sticky-container.state-2 {
-    background-color: #1a202c;
-}
-.painpoint-sticky-container.state-3 {
-    background-color: #f59e0b;
-}
-.painpoint-sticky-container.state-4 {
-    background-color: #3b82f6;
+.painpoint-sticky-container.state-5 {
+    background-color: #f3f4f6;
+    position: relative;
+    height: auto;
+    overflow: visible;
 }
 .painpoint-text-wrapper {
     position: relative;
@@ -281,18 +279,42 @@ body {
     justify-content: center;
     align-items: center;
     width: 100%;
+    height: 100%;
     max-width: 900px;
     margin: 0 auto;
 }
+.painpoint-sticky-container.state-5 .painpoint-text-wrapper {
+    display: none;
+}
+#services {
+    display: none;
+}
+.painpoint-sticky-container.state-5 #services {
+    display: block;
+}
 .painpoint-text {
     position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) translateY(20px);
     text-align: center;
     opacity: 0;
-    transform: translateY(20px);
     transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 .painpoint-text.active {
     opacity: 1;
-    transform: translateY(0);
+    transform: translate(-50%, -50%) translateY(0);
+}
+.painpoint-sticky-container.state-1 .painpoint-text.active {
+    background-color: #FF5722;
+}
+.painpoint-sticky-container.state-2 .painpoint-text.active {
+    background-color: #1a202c;
+}
+.painpoint-sticky-container.state-3 .painpoint-text.active {
+    background-color: #f59e0b;
+}
+.painpoint-sticky-container.state-4 .painpoint-text.active {
+    background-color: #3b82f6;
 }
 /* --- ENDE: Painpoint Parallax Bereich --- */


### PR DESCRIPTION
## Summary
- Center painpoint texts and show colored boxes on dark backdrop
- Fold "MEINE LEISTUNGEN" into parallax flow as fifth step
- Add fifth parallax state logic with grey background for services

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894eba091cc832db7abb25fc0bbb862